### PR TITLE
Change envsubst installation command

### DIFF
--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -106,7 +106,7 @@ apt update -y && apt upgrade -y && apt autoremove -y
 
 apt install docker.io docker-compose golang-go build-essential bc git curl httpie jq nano wget bsdmainutils base58 netcat net-tools libsecret-1-dev python2.7 clang cmake apache2-utils -y
 
-go install github.com/a8m/envsubst/cmd/envsubst@latest
+go get github.com/a8m/envsubst/cmd/envsubst
 
 ```
 


### PR DESCRIPTION
I noticed the `install` command was not working when setting up a new indexer. This command worked, and here is where I found it https://pkg.go.dev/github.com/a8m/envsubst#section-readme